### PR TITLE
Account for execution time

### DIFF
--- a/timeloop/app.py
+++ b/timeloop/app.py
@@ -48,8 +48,11 @@ class Timeloop():
 
     def job(self, interval):
         def decorator(f):
-            self._add_job(f, interval)
-            return f
+            def wrapper(*args, **kwargs):
+                self._add_job(f, interval, *args, **kwargs)
+                return f
+            return wrapper
+
         return decorator
 
     def stop(self):

--- a/timeloop/job.py
+++ b/timeloop/job.py
@@ -1,5 +1,6 @@
 from threading import Thread, Event
 from datetime import timedelta
+from time import time
 
 class Job(Thread):
     def __init__(self, interval, execute, *args, **kwargs):
@@ -15,5 +16,10 @@ class Job(Thread):
         self.join()
 
     def run(self):
-        while not self.stopped.wait(self.interval.total_seconds()):
+        next_period = self.interval.total_seconds()
+        next_time = time()
+
+        while not self.stopped.wait(next_period):
             self.execute(*self.args, **self.kwargs)
+            next_time += self.interval.total_seconds()
+            next_period = next_time - time()


### PR DESCRIPTION
Account for job execution time, so the job can be triggered at uniform intervals.
Pass keyword arguments other than `interval` to the target job.