### PR TITLE
Run on start

### DIFF
--- a/timeloop/app.py
+++ b/timeloop/app.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import sys
 import signal
@@ -20,8 +21,8 @@ class Timeloop():
         logger.setLevel(logging.INFO)
         self.logger = logger
 
-    def _add_job(self, func, interval, init_on_start, *args, **kwargs):
-        j = Job(interval, init_on_start, func, *args, **kwargs)
+    def _add_job(self, func, interval, run_on_start, *args, **kwargs):
+        j = Job(interval, run_on_start, func, *args, **kwargs)
         self.jobs.append(j)
 
     def _block_main_thread(self):
@@ -46,9 +47,12 @@ class Timeloop():
             self.logger.info("Stopping job {}".format(j.execute))
             j.stop()
 
-    def job(self, interval, init_on_start=False):
+    def job(self, interval=None, run_on_start=False):
+        if not interval or not isinstance(interval, datetime.timedelta):
+            raise TypeError('interval must be a timedelta and cannot be None')
+
         def decorator(f):
-            self._add_job(f, interval, init_on_start)
+            self._add_job(f, interval, run_on_start)
             return f
         return decorator
 

--- a/timeloop/app.py
+++ b/timeloop/app.py
@@ -20,8 +20,8 @@ class Timeloop():
         logger.setLevel(logging.INFO)
         self.logger = logger
 
-    def _add_job(self, func, interval, *args, **kwargs):
-        j = Job(interval, func, *args, **kwargs)
+    def _add_job(self, func, interval, init_on_start, *args, **kwargs):
+        j = Job(interval, init_on_start, func, *args, **kwargs)
         self.jobs.append(j)
 
     def _block_main_thread(self):
@@ -46,9 +46,9 @@ class Timeloop():
             self.logger.info("Stopping job {}".format(j.execute))
             j.stop()
 
-    def job(self, interval):
+    def job(self, interval, init_on_start=False):
         def decorator(f):
-            self._add_job(f, interval)
+            self._add_job(f, interval, init_on_start)
             return f
         return decorator
 

--- a/timeloop/job.py
+++ b/timeloop/job.py
@@ -3,11 +3,11 @@ from datetime import timedelta
 
 
 class Job(Thread):
-    def __init__(self, interval, init_on_start, execute, *args, **kwargs):
+    def __init__(self, interval, run_on_start, execute, *args, **kwargs):
         Thread.__init__(self)
         self.stopped = Event()
         self.interval = interval
-        self.init_on_start = init_on_start
+        self.run_on_start = run_on_start
         self.execute = execute
         self.args = args
         self.kwargs = kwargs
@@ -17,7 +17,7 @@ class Job(Thread):
         self.join()
 
     def run(self):
-        if self.init_on_start:
+        if self.run_on_start:
             self.execute(*self.args, **self.kwargs)
 
         while not self.stopped.wait(self.interval.total_seconds()):

--- a/timeloop/job.py
+++ b/timeloop/job.py
@@ -1,5 +1,6 @@
+import logging
+
 from threading import Thread, Event
-from datetime import timedelta
 
 
 class Job(Thread):
@@ -11,6 +12,7 @@ class Job(Thread):
         self.execute = execute
         self.args = args
         self.kwargs = kwargs
+        self.logger = logging.getLogger('timeloop')
 
     def stop(self):
         self.stopped.set()
@@ -18,7 +20,9 @@ class Job(Thread):
 
     def run(self):
         if self.run_on_start:
+            self.logger.info("Executing on start: {}".format(self.execute))
             self.execute(*self.args, **self.kwargs)
 
         while not self.stopped.wait(self.interval.total_seconds()):
+            self.logger.info("Executing on interval: {}".format(self.execute))
             self.execute(*self.args, **self.kwargs)

--- a/timeloop/job.py
+++ b/timeloop/job.py
@@ -1,11 +1,13 @@
 from threading import Thread, Event
 from datetime import timedelta
 
+
 class Job(Thread):
-    def __init__(self, interval, execute, *args, **kwargs):
+    def __init__(self, interval, init_on_start, execute, *args, **kwargs):
         Thread.__init__(self)
         self.stopped = Event()
         self.interval = interval
+        self.init_on_start = init_on_start
         self.execute = execute
         self.args = args
         self.kwargs = kwargs
@@ -15,5 +17,8 @@ class Job(Thread):
         self.join()
 
     def run(self):
+        if self.init_on_start:
+            self.execute(*self.args, **self.kwargs)
+
         while not self.stopped.wait(self.interval.total_seconds()):
             self.execute(*self.args, **self.kwargs)


### PR DESCRIPTION
closes #14 

This PR adds the capacity for jobs to run when the app starts in addition to its configured interval.  It also adds some logging for when things execute so that we can check logs to see that everything is still running.

I believe I also removed an unused import and fixed a pep8 suggestion of an extra line somewhere.

I've tested this in my own app [here](https://github.com/jar349/gold-price-scraper/blob/master/Pipfile#L14) and it works.