### PR TITLE
run tasks immediately instead of waiting for timers to expire

### DIFF
--- a/timeloop/job.py
+++ b/timeloop/job.py
@@ -15,5 +15,7 @@ class Job(Thread):
         self.join()
 
     def run(self):
-        while not self.stopped.wait(self.interval.total_seconds()):
+        while True:
             self.execute(*self.args, **self.kwargs)
+            if self.stopped.wait(self.interval.total_seconds()):
+                break

--- a/timeloop/job.py
+++ b/timeloop/job.py
@@ -15,7 +15,10 @@ class Job(Thread):
         self.join()
 
     def run(self):
-        while True:
-            self.execute(*self.args, **self.kwargs)
-            if self.stopped.wait(self.interval.total_seconds()):
-                break
+        stopped = self.stopped
+        timeout = self.interval.total_seconds()
+        task = self.execute
+        
+        while not stopped.is_set():
+            task(*self.args, **self.kwargs)
+            stopped.wait(timeout)


### PR DESCRIPTION
I want to see my tasks run immediately instead of waiting for the timers to expire.