### PR TITLE
Add job execution limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ pip install timeloop
 ```
 
 ## Writing jobs
+The jobs run the first time after the first wait interval.
+
 ```python
 import time
 
@@ -48,6 +50,20 @@ tl = Timeloop()
 def run_me_twice_with_10s_pause():
     print("10s job current time : {}".format(time.ctime()))
 ```
+
+## Jobs with a different initial interval
+At times, you want 
+```python
+@tl.job(interval=timedelta(seconds=1), initial_delay=timedelta(seconds=10))
+def run_after10s_and_then_every_second():
+    print("job current time : {}".format(time.ctime()))
+
+
+@tl.job(interval=timedelta(seconds=1), num_executions=2, initial_delay=timedelta(seconds=10))
+def run_after10s_and_then_after_1second_then_stop():
+    print("job current time : {}".format(time.ctime()))
+```
+
 
 ## Start time loop in separate thread
 By default timeloop starts in a separate thread.

--- a/README.md
+++ b/README.md
@@ -21,16 +21,32 @@ tl = Timeloop()
 
 @tl.job(interval=timedelta(seconds=2))
 def sample_job_every_2s():
-    print "2s job current time : {}".format(time.ctime())
+    print("2s job current time : {}".format(time.ctime()))
 
 @tl.job(interval=timedelta(seconds=5))
 def sample_job_every_5s():
-    print "5s job current time : {}".format(time.ctime())
+    print("5s job current time : {}".format(time.ctime()))
 
 
 @tl.job(interval=timedelta(seconds=10))
 def sample_job_every_10s():
-    print "10s job current time : {}".format(time.ctime())
+    print("10s job current time : {}".format(time.ctime()))
+```
+
+## Jobs that only run a certain amount of time
+By default, all jobs run until they are stopped. At times you may want to run a job only once or twice.
+
+```python
+import time
+
+from timeloop import Timeloop
+from datetime import timedelta
+
+tl = Timeloop()
+
+@tl.job(interval=timedelta(seconds=10), num_executions=2)
+def run_me_twice_with_10s_pause():
+    print("10s job current time : {}".format(time.ctime()))
 ```
 
 ## Start time loop in separate thread

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
  name='timeloop',
- version='1.0.2',
+ version='1.0.3',
  packages=['timeloop'],
  license = 'MIT',
  description = 'An elegant way to run period tasks.',

--- a/timeloop/app.py
+++ b/timeloop/app.py
@@ -2,6 +2,7 @@ import logging
 import signal
 import sys
 import time
+from datetime import timedelta
 
 from timeloop.exceptions import ServiceExit
 from timeloop.helpers import service_shutdown
@@ -46,9 +47,12 @@ class Timeloop():
             self.logger.info("Stopping job {}".format(j.execute))
             j.stop()
 
-    def job(self, interval, num_executions: int = Job.UNLIMITED_EXECUTION):
+    def job(self, interval: timedelta, num_executions: int = Job.UNLIMITED_EXECUTION, initial_delay: timedelta = None):
+        if initial_delay is None:
+            initial_delay = interval
+
         def decorator(f):
-            self._add_job(f, interval, num_executions=num_executions)
+            self._add_job(f, interval, num_executions=num_executions, initial_delay=initial_delay)
             return f
 
         return decorator

--- a/timeloop/app.py
+++ b/timeloop/app.py
@@ -1,11 +1,11 @@
 import logging
-import sys
 import signal
+import sys
 import time
 
 from timeloop.exceptions import ServiceExit
-from timeloop.job import Job
 from timeloop.helpers import service_shutdown
+from timeloop.job import Job
 
 
 class Timeloop():
@@ -46,10 +46,11 @@ class Timeloop():
             self.logger.info("Stopping job {}".format(j.execute))
             j.stop()
 
-    def job(self, interval):
+    def job(self, interval, num_executions: int = Job.UNLIMITED_EXECUTION):
         def decorator(f):
-            self._add_job(f, interval)
+            self._add_job(f, interval, num_executions=num_executions)
             return f
+
         return decorator
 
     def stop(self):

--- a/timeloop/job.py
+++ b/timeloop/job.py
@@ -1,3 +1,4 @@
+import datetime
 from threading import Thread, Event
 
 
@@ -5,8 +6,9 @@ class Job(Thread):
     UNLIMITED_EXECUTION = None
 
     NUM_EXEC_KEYWORD = "num_executions"
+    INITIAL_DELAY_KEYWORD = "initial_delay"
 
-    def __init__(self, interval, execute, *args, **kwargs):
+    def __init__(self, interval: datetime.timedelta, execute, *args, **kwargs):
         Thread.__init__(self)
         self.stopped = Event()
         self.interval = interval
@@ -17,6 +19,11 @@ class Job(Thread):
             self.num_executions = kwargs.pop(Job.NUM_EXEC_KEYWORD)
         else:
             self.num_executions = Job.UNLIMITED_EXECUTION
+        # to preserve the existing interface, get delay_execution from kwargs
+        if Job.INITIAL_DELAY_KEYWORD in kwargs.keys():
+            self.initial_delay = kwargs.pop(Job.INITIAL_DELAY_KEYWORD)
+        else:
+            self.initial_delay = interval
 
         self.kwargs = kwargs
         self.__counter = 0
@@ -25,9 +32,15 @@ class Job(Thread):
         self.stopped.set()
         self.join()
 
+    def _set_check_counter_and_stop(self):
+        self.__counter += 1
+        if self.num_executions and self.__counter >= self.num_executions:
+            self.stopped.set()
+
     def run(self):
+        if not self.stopped.wait(self.initial_delay.total_seconds()):
+            self.execute(*self.args, **self.kwargs)
+            self._set_check_counter_and_stop()
         while not self.stopped.wait(self.interval.total_seconds()):
             self.execute(*self.args, **self.kwargs)
-            self.__counter += 1
-            if self.num_executions and self.__counter >= self.num_executions:
-                self.stopped.set()
+            self._set_check_counter_and_stop()

--- a/timeloop/job.py
+++ b/timeloop/job.py
@@ -2,13 +2,24 @@ from threading import Thread, Event
 
 
 class Job(Thread):
+    UNLIMITED_EXECUTION = None
+
+    NUM_EXEC_KEYWORD = "num_executions"
+
     def __init__(self, interval, execute, *args, **kwargs):
         Thread.__init__(self)
         self.stopped = Event()
         self.interval = interval
         self.execute = execute
         self.args = args
+        # to preserve the existing interface, get num_executions from kwargs
+        if Job.NUM_EXEC_KEYWORD in kwargs.keys():
+            self.num_executions = kwargs.pop(Job.NUM_EXEC_KEYWORD)
+        else:
+            self.num_executions = Job.UNLIMITED_EXECUTION
+
         self.kwargs = kwargs
+        self.__counter = 0
 
     def stop(self):
         self.stopped.set()
@@ -17,3 +28,6 @@ class Job(Thread):
     def run(self):
         while not self.stopped.wait(self.interval.total_seconds()):
             self.execute(*self.args, **self.kwargs)
+            self.__counter += 1
+            if self.num_executions and self.__counter >= self.num_executions:
+                self.stopped.set()

--- a/timeloop/job.py
+++ b/timeloop/job.py
@@ -1,5 +1,5 @@
 from threading import Thread, Event
-from datetime import timedelta
+
 
 class Job(Thread):
     def __init__(self, interval, execute, *args, **kwargs):


### PR DESCRIPTION
- Added execution limits to the jobs, execute only a certain amount of numbers, or forever (default)
- Added optional initial delay, if the first execution shall be done immediately or with a higher/lower delay as the interval, this option can be used
- updated the README accordingly
- version bump